### PR TITLE
fix(solaar): add hid-parser dependency and autostart desktop entry

### DIFF
--- a/build/30-solaar.sh
+++ b/build/30-solaar.sh
@@ -7,6 +7,7 @@ set -oue pipefail
 echo "::group:: Installing solaar..."
 
 dnf install -y solaar solaar-udev
+pip3 install --target "$(python3 -c 'import sysconfig; print(sysconfig.get_path("purelib"))')" hid-parser
 
 echo "solaar installed successfully"
 echo "::endgroup::"

--- a/custom/etc/skel/.config/autostart/solaar.desktop
+++ b/custom/etc/skel/.config/autostart/solaar.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Type=Application
+Name=Solaar
+Exec=/usr/bin/solaar --window=hide
+Hidden=false
+NoDisplay=true
+X-GNOME-Autostart-enabled=true


### PR DESCRIPTION
- Install hid-parser via pip to system site-packages (required by solaar)
- Add solaar.desktop to skel autostart for auto-launch on login
- Use sysconfig for portable Python site-packages path

Assisted-by: big-pickle via opencode